### PR TITLE
Implement registers as a union

### DIFF
--- a/Z80_CPU.cpp
+++ b/Z80_CPU.cpp
@@ -3,6 +3,13 @@
 Z80_CPU::Z80_CPU(void)
 {
 	ram.fill(69);
+
+	AF.value = 0x00;
+	BC.value = 0x00;
+	DE.value = 0x00;
+	HL.value = 0x00;
+	SP.value = 0x00;
+	PC.value = 0x00;
 }
 
 Z80_CPU::~Z80_CPU(void)
@@ -39,8 +46,8 @@ void Z80_CPU::write(int16_t address, int8_t data)
 
 void Z80_CPU::IMMEDIATE()
 {
-	abs_addr = PC;
-	PC++;
+	abs_addr = PC.value;
+	PC.value++;
 }
 
 /*
@@ -50,8 +57,7 @@ void Z80_CPU::IMMEDIATE()
 
 void Z80_CPU::INDIRECT_REGISTER_HL()
 {
-	abs_addr = (int16_t)0 | H << 8;
-	abs_addr = abs_addr | L;
+	abs_addr = HL.value;
 }
 
 /*
@@ -61,8 +67,7 @@ void Z80_CPU::INDIRECT_REGISTER_HL()
 
 void Z80_CPU::INDIRECT_REGISTER_DE()
 {
-	abs_addr = (int16_t)0 | D << 8;
-	abs_addr = abs_addr | E;
+	abs_addr = DE.value;
 }
 
 /*
@@ -75,12 +80,12 @@ void Z80_CPU::EXTENDED_ADDR()
 	int8_t hi;
 	int8_t lo;
 
-	hi = read(PC);
-	PC++;
-	lo = read(PC);
-	PC++;
+	hi = read(PC.value);
+	PC.value++;
+	lo = read(PC.value);
+	PC.value++;
 
-	abs_addr = hi << 8 | lo;
+	abs_addr = (int16_t)hi << 8 | (int16_t)lo;
 }
 
 /*
@@ -90,8 +95,8 @@ void Z80_CPU::EXTENDED_ADDR()
 
 void Z80_CPU::RELATIVE_ADDR()
 {
-	rel_addr = read(PC);
-	PC++;
+	rel_addr = read(PC.value);
+	PC.value++;
 }
 
 /*
@@ -144,10 +149,10 @@ void Z80_CPU::LD_B_HL()
 {
 	INDIRECT_REGISTER_HL();
 	fetch();
-	WR_REGISTER(REGISTER_ACCESS_MODE::WRITE, B);
+	WR_REGISTER(REGISTER_ACCESS_MODE::WRITE, BC.hi);
 }
 
-/* 
+/*
 	Load to 8-bit register data from absolute address in the next two bytes in the instruction
 */
 
@@ -155,5 +160,5 @@ void Z80_CPU::LD_A_nn()
 {
 	EXTENDED_ADDR();
 	fetch();
-	WR_REGISTER(REGISTER_ACCESS_MODE::WRITE, A);
+	WR_REGISTER(REGISTER_ACCESS_MODE::WRITE, AF.hi);
 }

--- a/Z80_CPU.h
+++ b/Z80_CPU.h
@@ -21,21 +21,20 @@ public:
 	};
 
 	// opcodes maps
-	std::map<int8_t, R8_R8> opcodes_ld_r_r { 
-		{0x40, {B, B}}, {0x41, {B, C}}, {0x42, {B, D}}, {0x43, {B, E}}, {0x44, {B, H}}, {0x45, {B, L}}, {0x47, {B, A}}, {0x48, {C, B}}, {0x49, {C, C}}, {0x4A, {C, D}}, {0x4B, {C, E}}, {0x4C, {C, H}}, {0x4D, {C, L}}, {0x4F, {C, A}}, 
-		{0x50, {D, B}}, {0x51, {D, C}}, {0x52, {D, D}}, {0x53, {D, E}}, {0x54, {D, H}}, {0x55, {D, L}}, {0x57, {D, A}}, {0x58, {E, B}}, {0x59, {E, C}}, {0x5A, {E, D}}, {0x5B, {E, E}}, {0x5C, {E, H}}, {0x5D, {E, L}}, {0x5F, {E, A}}, 
-		{0x60, {H, B}}, {0x61, {H, C}}, {0x62, {H, D}}, {0x63, {H, E}}, {0x64, {H, H}}, {0x65, {H, L}}, {0x67, {H, A}}, {0x68, {L, B}}, {0x69, {L, C}}, {0x6A, {L, D}}, {0x6B, {L, E}}, {0x6C, {L, H}}, {0x6D, {L, L}}, {0x6F, {L, A}}, 
-		{0x78, {A, B}}, {0x79, {A, C}}, {0x7A, {A, D}}, {0x7B, {A, E}}, {0x7C, {A, H}}, {0x7D, {A, L}}, {0x7F, {A, A}}, 
+	std::map<int8_t, R8_R8> opcodes_ld_r_r  { 
+		{0x40, {BC.hi, BC.hi}}, {0x41, {BC.hi, BC.lo}}, {0x42, {BC.hi, DE.hi}}, {0x43, {BC.hi, DE.lo}}, {0x44, {BC.hi, HL.hi}}, {0x45, {BC.hi, HL.lo}}, {0x47, {BC.hi, AF.hi}}, {0x48, {BC.lo, BC.hi}}, {0x49, {BC.lo, BC.lo}}, {0x4A, {BC.lo, DE.hi}}, {0x4B, {BC.lo, DE.lo}}, {0x4C, {BC.lo, HL.hi}}, {0x4D, {BC.lo, HL.lo}}, {0x4F, {BC.lo, AF.hi}}, 
+		{0x50, {DE.hi, BC.hi}}, {0x51, {DE.hi, BC.lo}}, {0x52, {DE.hi, DE.hi}}, {0x53, {DE.hi, DE.lo}}, {0x54, {DE.hi, HL.hi}}, {0x55, {DE.hi, HL.lo}}, {0x57, {DE.hi, AF.hi}}, {0x58, {DE.lo, BC.hi}}, {0x59, {DE.lo, BC.lo}}, {0x5A, {DE.lo, DE.hi}}, {0x5B, {DE.lo, DE.lo}}, {0x5C, {DE.lo, HL.hi}}, {0x5D, {DE.lo, HL.lo}}, {0x5F, {DE.lo, AF.hi}}, 
+		{0x60, {HL.hi, BC.hi}}, {0x61, {HL.hi, BC.lo}}, {0x62, {HL.hi, DE.hi}}, {0x63, {HL.hi, DE.lo}}, {0x64, {HL.hi, HL.hi}}, {0x65, {HL.hi, HL.lo}}, {0x67, {HL.hi, AF.hi}}, {0x68, {HL.lo, BC.hi}}, {0x69, {HL.lo, BC.lo}}, {0x6A, {HL.lo, DE.hi}}, {0x6B, {HL.lo, DE.lo}}, {0x6C, {HL.lo, HL.hi}}, {0x6D, {HL.lo, HL.lo}}, {0x6F, {HL.lo, AF.hi}}, 
+		{0x78, {AF.hi, BC.hi}}, {0x79, {AF.hi, BC.lo}}, {0x7A, {AF.hi, DE.hi}}, {0x7B, {AF.hi, DE.lo}}, {0x7C, {AF.hi, HL.hi}}, {0x7D, {AF.hi, HL.lo}}, {0x7F, {AF.hi, AF.hi}}, 
 	};
 
 	/* {0x36, [LD (HL), n]} => not included in this map!! */
-	std::map<int8_t, int8_t&> opcodes_ld_r_n {
-		{0x6, B}, {0xE, C}, 
-		{0x16, D}, {0x1E, E}, 
-		{0x26, H}, {0x2E, L}, 
-		{0x3E, A}, 
-	}; 
-
+	std::map<int8_t, int8_t &> opcodes_ld_r_n {
+		{0x6, BC.hi}, {0xE, BC.lo}, 
+		{0x16, DE.hi}, {0x1E, DE.lo}, 
+		{0x26, HL.hi}, {0x2E, HL.lo}, 
+		{0x3E, AF.hi}, 
+	};
 
 	// 8-bit instructions
 	void LD_8BIT_REGISTER_TO_8BIT_REGISTER(int8_t &reg1, int8_t &reg2);
@@ -64,21 +63,27 @@ public:
 	void RELATIVE_ADDR();
 	void WR_REGISTER(REGISTER_ACCESS_MODE type, int8_t &reg);
 
+	union REG
+	{
+		struct
+		{	
+			int8_t hi;
+			int8_t lo;
+		};
+		int16_t value;
+	};
+
     // Registers
-	int8_t A = 0x00; // A = Accumulator
-	int8_t F = 0x00; // F = flags
+	REG AF;
 
-	int8_t B = 0x00;
-	int8_t C = 0x00;
+	REG BC;
 
-	int8_t D = 0x00;
-	int8_t E = 0x00;
+	REG DE;
 
-	int8_t H = 0x00;
-	int8_t L = 0x00;
+	REG HL;
 
-	int16_t SP = 0x00; // Stack Pointer
-	int16_t PC = 0x00; // Program Counter/Pointer
+	REG SP; // stack pointer
+	REG PC; // Program Counter/Pointer
 
 	int16_t abs_addr = 0x00;
 	int8_t  rel_addr = 0x00;

--- a/main.cpp
+++ b/main.cpp
@@ -2,60 +2,59 @@
 #include <iostream>
 #include "./Z80_CPU.h"
 
-void print_registers(Z80_CPU cpu)
-{
-    std::cout << std::endl;
-    std::cout << "=======================" << std::endl;
-    std::cout << "A : " << (int)cpu.A << " | F: " << (int)cpu.F << std::endl;
-    std::cout << "B : " << (int)cpu.B << " | C: " << (int)cpu.C << std::endl;
-    std::cout << "D : " << (int)cpu.D << " | E: " << (int)cpu.E << std::endl;
-    std::cout << "H : " << (int)cpu.H << " | L: " << (int)cpu.L << std::endl;
-    std::cout << "SP : " << (int)cpu.SP << " | PC: " << (int)cpu.PC << std::endl;
-    std::cout << "ABS_ADDR : " << (int)cpu.abs_addr << " | REL_ADDR: " << (int)cpu.rel_addr << std::endl;
-    std::cout << "DATA : " << (int)cpu.data << std::endl;
-    std::cout << "=======================" << std::endl;
-    std::cout << std::endl;
-}
+// void print_registers(Z80_CPU cpu)
+// {
+//     std::cout << std::endl;
+//     std::cout << "=======================" << std::endl;
+//     std::cout << "A : " << (int)cpu.A << " | F: " << (int)cpu.F << std::endl;
+//     std::cout << "B : " << (int)cpu.B << " | C: " << (int)cpu.C << std::endl;
+//     std::cout << "D : " << (int)cpu.D << " | E: " << (int)cpu.E << std::endl;
+//     std::cout << "H : " << (int)cpu.H << " | L: " << (int)cpu.L << std::endl;
+//     std::cout << "SP : " << (int)cpu.SP << " | PC: " << (int)cpu.PC << std::endl;
+//     std::cout << "ABS_ADDR : " << (int)cpu.abs_addr << " | REL_ADDR: " << (int)cpu.rel_addr << std::endl;
+//     std::cout << "DATA : " << (int)cpu.data << std::endl;
+//     std::cout << "=======================" << std::endl;
+//     std::cout << std::endl;
+// }
 
-bool exec_opcode(Z80_CPU cpu, int opcode) {
-    auto search_r_r = cpu.opcodes_ld_r_r.find(opcode);
-    if (search_r_r != cpu.opcodes_ld_r_r.end()) {
-        std::cout << "Hello From REGISTER TO REGISTER" << std::endl;
-        cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER((search_r_r->second).reg1, (search_r_r->second).reg2);
-        return true;
-    }
-    auto search_r_n = cpu.opcodes_ld_r_n.find(opcode);
-    if (search_r_n != cpu.opcodes_ld_r_n.end()) {
-        std::cout << "Hello From IMMEDIATE DATA TO REGISTER" << std::endl;
-        cpu.LD_IMMEDIATE_8BIT_DATA_TO_8BIT_REGISTER(search_r_n->second);
-        return true;
-    }
-    return false;
-}
+// bool exec_opcode(Z80_CPU cpu, int opcode) {
+//     auto search_r_r = cpu.opcodes_ld_r_r.find(opcode);
+//     if (search_r_r != cpu.opcodes_ld_r_r.end()) {
+//         std::cout << "Hello From REGISTER TO REGISTER" << std::endl;
+//         cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER((search_r_r->second).reg1, (search_r_r->second).reg2);
+//         return true;
+//     }
+//     auto search_r_n = cpu.opcodes_ld_r_n.find(opcode);
+//     if (search_r_n != cpu.opcodes_ld_r_n.end()) {
+//         std::cout << "Hello From IMMEDIATE DATA TO REGISTER" << std::endl;
+//         cpu.LD_IMMEDIATE_8BIT_DATA_TO_8BIT_REGISTER(search_r_n->second);
+//         return true;
+//     }
+//     return false;
+// }
 
 int main(void)
 {
-    Z80_CPU cpu;
-    int  opcode;
+    // int  opcode;
 
-    cpu.A = 42;
-    cpu.F = 43;
-    cpu.B = 44;
-    cpu.C = 45;
-    cpu.D = 46;
-    cpu.E = 47;
-    cpu.H = 48;
-    cpu.L = 49;
-    while (1) {
-        print_registers(cpu);
-        std::cout << "Enter the opcode in Hexadecimal: ";
-        std::cin >> std::hex >> opcode;
-        std::cout << std::endl;
-        std::cout << "Opcode entered: " << opcode << std::endl;
+    // cpu.A = 42;
+    // cpu.F = 43;
+    // cpu.B = 44;
+    // cpu.C = 45;
+    // cpu.D = 46;
+    // cpu.E = 47;
+    // cpu.H = 48;
+    // cpu.L = 49;
+    // while (1) {
+    //     print_registers(cpu);
+    //     std::cout << "Enter the opcode in Hexadecimal: ";
+    //     std::cin >> std::hex >> opcode;
+    //     std::cout << std::endl;
+    //     std::cout << "Opcode entered: " << opcode << std::endl;
         
-        if (!exec_opcode(cpu, opcode)){
-            std::cout << "Not implemented yet!!!" << std::endl;
-        }
-    }
+    //     if (!exec_opcode(cpu, opcode)){
+    //         std::cout << "Not implemented yet!!!" << std::endl;
+    //     }
+    // }
     return 0;
 }

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -11,9 +11,9 @@ TEST(RegisterLoadingTests, loadToA)
 {
     const int8_t value = 24;
 
-    g_cpu.F = value;
-    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.A, g_cpu.F);
-    EXPECT_EQ(g_cpu.A, value);
+    g_cpu.AF.lo = value;
+    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.AF.hi, g_cpu.AF.lo);
+    EXPECT_EQ(g_cpu.AF.hi, value);
 }
 
 // Load to register B
@@ -21,9 +21,9 @@ TEST(RegisterLoadingTests, loadToB)
 {
     const int8_t value = 120;
 
-    g_cpu.C = value;
-    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.B, g_cpu.C);
-    EXPECT_EQ(g_cpu.B, value);
+    g_cpu.BC.lo = value;
+    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.BC.hi, g_cpu.BC.lo);
+    EXPECT_EQ(g_cpu.BC.hi, value);
 }
 
 // Load to register C
@@ -31,9 +31,9 @@ TEST(RegisterLoadingTests, loadToC)
 {
     const int8_t value = -1;
 
-    g_cpu.D = value;
-    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.C, g_cpu.D);
-    EXPECT_EQ(g_cpu.C, value);
+    g_cpu.DE.hi = value;
+    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.BC.lo, g_cpu.DE.hi);
+    EXPECT_EQ(g_cpu.BC.lo, value);
 }
 
 // Load to register F
@@ -41,9 +41,9 @@ TEST(RegisterLoadingTests, loadToF)
 {
     const int8_t value = 41;
 
-    g_cpu.L = value;
-    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.F, g_cpu.L);
-    EXPECT_EQ(g_cpu.F, value);
+    g_cpu.HL.lo = value;
+    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.AF.lo, g_cpu.HL.lo);
+    EXPECT_EQ(g_cpu.AF.lo, value);
 }
 
 // Load to register D
@@ -51,9 +51,9 @@ TEST(RegisterLoadingTests, loadToD)
 {
     const int8_t value = 10;
 
-    g_cpu.A = value;
-    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.D, g_cpu.A);
-    EXPECT_EQ(g_cpu.D, value);
+    g_cpu.AF.hi = value;
+    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.DE.hi, g_cpu.AF.hi);
+    EXPECT_EQ(g_cpu.DE.hi, value);
 }
 
 // Load to register E
@@ -61,9 +61,9 @@ TEST(RegisterLoadingTests, loadToE)
 {
     const int8_t value = 15;
 
-    g_cpu.D = value;
-    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.E, g_cpu.D);
-    EXPECT_EQ(g_cpu.E, value);
+    g_cpu.DE.hi = value;
+    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.DE.lo, g_cpu.DE.hi);
+    EXPECT_EQ(g_cpu.DE.lo, value);
 }
 
 // Load to register H
@@ -71,9 +71,9 @@ TEST(RegisterLoadingTests, loadToH)
 {
     const int8_t value = -45;
 
-    g_cpu.B = value;
-    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.H, g_cpu.B);
-    EXPECT_EQ(g_cpu.H, g_cpu.B);
+    g_cpu.BC.hi = value;
+    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.HL.hi, g_cpu.BC.hi);
+    EXPECT_EQ(g_cpu.HL.hi, value);
 }
 
 // Load to register L
@@ -81,7 +81,7 @@ TEST(RegisterLoadingTests, loadToL)
 {
     const int8_t value = 0;
 
-    g_cpu.H = value;
-    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.L, g_cpu.H);
-    EXPECT_EQ(g_cpu.L, value);
+    g_cpu.HL.hi = value;
+    g_cpu.LD_8BIT_REGISTER_TO_8BIT_REGISTER(g_cpu.HL.lo, g_cpu.HL.hi);
+    EXPECT_EQ(g_cpu.HL.lo, value);
 }


### PR DESCRIPTION
This change is suppose to make accessing registers easier, with unions we can now access a 16-bit register as a whole as one element or two element for the hi and lo parts.
