### PR TITLE
implement Ld, A, (BC)

### DIFF
--- a/Z80_CPU.cpp
+++ b/Z80_CPU.cpp
@@ -71,6 +71,16 @@ void Z80_CPU::INDIRECT_REGISTER_DE()
 }
 
 /*
+	- Register Indirect Addressing (BC)
+	- 16-bit absolute address is in 16-bit register BC.
+*/
+
+void Z80_CPU::INDIRECT_REGISTER_BC()
+{
+	abs_addr = BC.value;
+}
+
+/*
 	- Extended addressing
 	- 16-bit absolute address is provided in the next two bytes of the instruction
 */
@@ -185,6 +195,18 @@ void Z80_CPU::LD_ABS_HL_n(void)
 	write(abs_addr, data);
 }
 
+/*
+	Instruction: LD A, (BC)
+	Description: Load to the 8-bit A register, data from the absolute address specified by the 16-bit register BC.
+	Opcode: 0b00001010
+*/
+
+void Z80_CPU::LD_A_ABS_BC(void)
+{
+	INDIRECT_REGISTER_BC();
+	fetch();
+	WR_REGISTER(REGISTER_ACCESS_MODE::WRITE, AF.hi);
+}
 
 /*
 	Load to 8-bit register data from absolute address in the next two bytes in the instruction

--- a/Z80_CPU.h
+++ b/Z80_CPU.h
@@ -51,7 +51,7 @@ public:
 	};
 
 	std::map<int8_t, const instruction> opcodes_others {
-		{0x36, &Z80_CPU::LD_ABS_HL_n},
+		{0x36, &Z80_CPU::LD_ABS_HL_n}, {0x0A, &Z80_CPU::LD_A_ABS_BC}
 	};
 
 	// 8-bit instructions
@@ -60,6 +60,7 @@ public:
 	void LD_r_ABS_HL(int8_t &reg);
 	void LD_ABS_HL_r(int8_t &reg);
 	void LD_ABS_HL_n(void);
+	void LD_A_ABS_BC(void);
 
 	void LD_A_nn();
 
@@ -82,6 +83,7 @@ public:
 	void INDIRECT_REGISTER_DE();
 	void EXTENDED_ADDR();
 	void RELATIVE_ADDR();
+	void INDIRECT_REGISTER_BC();
 	void WR_REGISTER(REGISTER_ACCESS_MODE type, int8_t &reg);
 
 	union REG


### PR DESCRIPTION
Instruction: LD A, (BC)
Description: Load to the 8-bit A register, data from the absolute address specified by the 16-bit register BC.
Opcode: 0b00001010