### PR TITLE
implement instruction LD A,(HL+)

### DIFF
--- a/Z80_CPU.cpp
+++ b/Z80_CPU.cpp
@@ -329,9 +329,12 @@ void Z80_CPU::LDH_A_ABS_n(void)
 
 /*
 	Instruction: LDH (n), A
-	Description: Load to the address specified by the 8-bit immediate data n, data from the 8-bit A register. The full 16-bit
-absolute address is obtained by setting the most significant byte to 0xFF and the least significant byte to the
-value of n, so the possible range is 0xFF00-0xFFFF.
+	
+	Description:
+	Load to the address specified by the 8-bit immediate data n, data from the 8-bit A register. The full 16-bit
+	absolute address is obtained by setting the most significant byte to 0xFF and the least significant byte to the
+	value of n, so the possible range is 0xFF00-0xFFFF.
+	
 	Opcode: 0b11100000
 */
 
@@ -342,4 +345,22 @@ void Z80_CPU::LDH_ABS_n_A(void)
 	set_msb_max_to_abs_addr(data);
 	WR_REGISTER(REGISTER_ACCESS_MODE::READ, AF.hi);
 	write(abs_addr, data);
+}
+
+/*
+	Instruction: LD A, (HL+)
+	
+	Description:
+	Load to the 8-bit A register, data from the absolute address specified by the 16-bit register HL. The value of HL is incremented after the memory read.
+	
+	Opcode: 0b00101010
+*/
+
+void Z80_CPU::LD_A_ABS_INCREMENT_HL(void)
+{
+	std::cout << "called LD_A_ABS_INCREMENT_HL" << std::endl;
+	INDIRECT_REGISTER_HL();
+	fetch();
+	WR_REGISTER(REGISTER_ACCESS_MODE::WRITE, AF.hi);
+	HL.value++;
 }

--- a/Z80_CPU.cpp
+++ b/Z80_CPU.cpp
@@ -358,7 +358,6 @@ void Z80_CPU::LDH_ABS_n_A(void)
 
 void Z80_CPU::LD_A_ABS_INCREMENT_HL(void)
 {
-	std::cout << "called LD_A_ABS_INCREMENT_HL" << std::endl;
 	INDIRECT_REGISTER_HL();
 	fetch();
 	WR_REGISTER(REGISTER_ACCESS_MODE::WRITE, AF.hi);

--- a/Z80_CPU.h
+++ b/Z80_CPU.h
@@ -56,7 +56,7 @@ public:
 		{0x12, &Z80_CPU::LD_ABS_DE_A}, {0xFA, &Z80_CPU::LD_A_ABS_nn},
 		{0xEA, &Z80_CPU::LD_ABS_nn_A}, {0xF2, &Z80_CPU::LDH_A_ABS_C},
 		{0xE2, &Z80_CPU::LDH_ABS_C_A}, {0xF0, &Z80_CPU::LDH_A_ABS_n},
-		{0xE0, &Z80_CPU::LDH_ABS_n_A},
+		{0xE0, &Z80_CPU::LDH_ABS_n_A}, {0x22, &Z80_CPU::LD_A_ABS_INCREMENT_HL}
 	};
 
 	// 8-bit instructions
@@ -75,7 +75,8 @@ public:
 	void LDH_ABS_C_A(void);
 	void LDH_A_ABS_n(void);
 	void LDH_ABS_n_A(void);
-	
+	void LD_A_ABS_INCREMENT_HL(void);
+
 	// Helpers
 	void fetch();
 	void set_msb_max_to_abs_addr(int8_t value);

--- a/Z80_CPU.h
+++ b/Z80_CPU.h
@@ -56,7 +56,7 @@ public:
 		{0x12, &Z80_CPU::LD_ABS_DE_A}, {0xFA, &Z80_CPU::LD_A_ABS_nn},
 		{0xEA, &Z80_CPU::LD_ABS_nn_A}, {0xF2, &Z80_CPU::LDH_A_ABS_C},
 		{0xE2, &Z80_CPU::LDH_ABS_C_A}, {0xF0, &Z80_CPU::LDH_A_ABS_n},
-		{0xE0, &Z80_CPU::LDH_ABS_n_A}, {0x22, &Z80_CPU::LD_A_ABS_INCREMENT_HL}
+		{0xE0, &Z80_CPU::LDH_ABS_n_A}, {0xA2, &Z80_CPU::LD_A_ABS_INCREMENT_HL}
 	};
 
 	// 8-bit instructions

--- a/main.cpp
+++ b/main.cpp
@@ -17,7 +17,7 @@ void print_registers(Z80_CPU cpu)
     std::cout << std::endl;
 }
 
-bool exec_opcode(Z80_CPU cpu, int opcode) {
+bool exec_opcode(Z80_CPU &cpu, int opcode) {
     auto search_r_r = cpu.opcodes_ld_r_r.find(opcode);
     if (search_r_r != cpu.opcodes_ld_r_r.end()) {
         std::cout << "Hello From REGISTER TO REGISTER" << std::endl;


### PR DESCRIPTION
Implement instruction `LD A,(HL+)`

Description:
Load to the 8-bit A register, data from the absolute address specified by the 16-bit register HL. The value of HL is incremented after the memory read.

Opcode: 0b00101010